### PR TITLE
Use macOS 10.9

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,24 +51,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,9 +2,5 @@
 
 # make sure that compiler has been sourced, if necessary
 
-if [ `uname` == Darwin ]; then
-    export MACOSX_DEPLOYMENT_TARGET=10.10
-fi
-
 CFLAGS="-I$PREFIX/include $CFLAGS" $PYTHON setup.py build --force install --old-and-unmanageable
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.0.1" %}
-{% set buildnumber = 0 %}
+{% set buildnumber = 1 %}
 
 package:
     name: mkl_fft


### PR DESCRIPTION
As `conda-forge` sets the [`MACOSX_DEPLOYMENT_TARGET` to `10.9` globally]( https://github.com/conda-forge/conda-forge-build-setup-feedstock/blob/69733d448e6d6475fc5726fe9f88bdc804a69711/recipe/run_conda_forge_build_setup_osx#L9 ), drop the setting from the build script so that it can leverage the same deployment target used in the rest of `conda-forge`. Bumps the build number to rebuild with this older macOS deployment target.