### PR TITLE
Add pip check to test suite

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   sha256: 6314b881b83f5e0cdffd91057cc31eafc14e7ba05f2ab1941d2ca9ede5eeb6ab
 
 build:
-  number: 0
+  number: 1
   ignore_run_exports:
     - blas
 
@@ -29,8 +29,10 @@ requirements:
 
 test:
   commands:
+    - pip check
     - pytest -v --pyargs mkl_fft
   requires:
+    - pip
     - pytest
     - scipy >=1.10
   imports:


### PR DESCRIPTION
Add `pip check` to the recipe test commands to catch undeclared or broken PyPI runtime dependencies at build time.

Motivated by a recent issue where `mkl-service 2.7.1` introduced `dependencies = ["mkl"]` in `pyproject.toml`, which breaks `pip check` in downstream conda environments since `mkl` ships no `.dist-info` on conda-forge. Adding this check here ensures similar regressions are caught in-recipe in the future.

See: IntelPython/mkl-service#201